### PR TITLE
Fixed mailer bug with mailgun

### DIFF
--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -6,8 +6,7 @@ module Commontator
     def comment_created(comment, recipients)
       setup_variables(comment, recipients)
 
-      mail :to => 'Undisclosed Recipients',
-           :bcc => @bcc,
+      mail :bcc => @bcc,
            :from => @from,
            :subject => @subject
     end


### PR DESCRIPTION
:to => 'Undisclosed Recipients' wasn't accepted by mailgun. Removed the ":to" to fix it
