### PR TITLE
The calls to render partial => "reply" when commontator_thread_show has ...

### DIFF
--- a/app/views/commontator/threads/_show.html.erb
+++ b/app/views/commontator/threads/_show.html.erb
@@ -38,7 +38,7 @@
 </span>
 
 <% if thread.config.comment_order == :l %>
-  <%= render :partial => 'reply', :locals => {:thread => thread, :user => user} %>
+  <%= render :partial => 'commontator/threads/reply', :locals => {:thread => thread, :user => user} %>
 <% end %>
 
 <div id="thread_<%= thread.id.to_s %>_comment_list_div" class="thread_comment_list">
@@ -56,5 +56,5 @@
 <% end %>
 
 <% if thread.config.comment_order != :l %>
-  <%= render :partial => 'reply', :locals => {:thread => thread, :user => user} %>
+  <%= render :partial => 'commontator/threads/reply', :locals => {:thread => thread, :user => user} %>
 <% end %>


### PR DESCRIPTION
...been called is causing issues redering with Rails 4.0.4 not finding the partial.

Callling it with the path "commontator/threads/reply" fixes the issue.
