### PR TITLE
Mailgun support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ If sending emails, remember to add your host URL's to your environment files
 config.action_mailer.default_url_options = { :host => "www.example.com" }
 ```
 
+Supported mailing services: Mailgun.
+
 ## Voting
 
 You can allow users to vote on each others' comments by adding the `acts_as_votable` gem to your gemfile:

--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -2,14 +2,15 @@ module Commontator
   class SubscriptionsMailer < ActionMailer::Base
     def comment_created(comment, recipients)
       setup_variables(comment, recipients)
+      message = mail :to => @to,
+                     :bcc => @bcc,
+                     :from => @from,
+                     :subject => t('commontator.email.comment_created.subject',
+                                   :creator_name => @creator_name,
+                                   :commontable_name => @commontable_name,
+                                   :commontable_url => @commontable_url)
 
-      mail :to => @to,
-           :bcc => @bcc,
-           :from => @from,
-           :subject => t('commontator.email.comment_created.subject',
-                         :creator_name => @creator_name,
-                         :commontable_name => @commontable_name,
-                         :commontable_url => @commontable_url)
+      message.mailgun_recipient_variables = mailgun_recipient_variables(recipients) if uses_mailgun?
     end
 
     protected
@@ -33,11 +34,28 @@ module Commontator
       params[:commontable_name] = @commontable_name
       params[:commontable_url] = @commontable_url
 
-      @to = t('commontator.email.undisclosed_recipients')
-      @bcc = recipients.collect{|s| Commontator.commontator_email(s, self)}
+      if uses_mailgun?
+        @to = recipient_emails(recipients)
+      else
+        @to = t('commontator.email.undisclosed_recipients')
+        @bcc = recipient_emails(recipients)
+      end
+
       @from = @thread.config.email_from_proc.call(@thread)
     end
 
-    
+    def recipient_emails(recipients)
+      recipients.collect{ |s| Commontator.commontator_email(s, self) }
+    end
+
+    def mailgun_recipient_variables(recipients)
+      recipient_emails(recipients).each_with_object({}) do |user_email, memo|
+        memo[user_email] = { label: user_email }
+      end
+    end
+
+    def uses_mailgun?
+      Rails.application.config.action_mailer.delivery_method == :mailgun
+    end
   end
 end

--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -50,7 +50,7 @@ module Commontator
 
     def mailgun_recipient_variables(recipients)
       recipient_emails(recipients).each_with_object({}) do |user_email, memo|
-        memo[user_email] = { label: user_email }
+        memo[user_email] = {}
       end
     end
 

--- a/commontator.gemspec
+++ b/commontator.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "acts_as_votable"
+  s.add_development_dependency "mailgun_rails"
 end

--- a/spec/mailers/commontator/subscriptions_mailer_spec.rb
+++ b/spec/mailers/commontator/subscriptions_mailer_spec.rb
@@ -29,7 +29,7 @@ module Commontator
 
     context 'uses Mailgun' do
       let(:recipient_variables) do
-        @recipients.each_with_object({}) { |user, memo| memo[user.email] = { label: user.email } }
+        @recipients.each_with_object({}) { |user, memo| memo[user.email] = {} }
       end
       before { allow(Rails.application.config.action_mailer).to receive(:delivery_method).and_return(:mailgun) }
 

--- a/spec/mailers/commontator/subscriptions_mailer_spec.rb
+++ b/spec/mailers/commontator/subscriptions_mailer_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'mailgun_rails'
 
 module Commontator
   RSpec.describe SubscriptionsMailer, type: :mailer do
@@ -16,7 +17,7 @@ module Commontator
     end
 
     it 'must create deliverable mail' do
-      mail = SubscriptionsMailer.comment_created(@comment, @recipients)
+      mail = described_class.comment_created(@comment, @recipients)
       expect(mail.to).to eq I18n.t('commontator.email.undisclosed_recipients')
       expect(mail.cc).to be_nil
       expect(mail.bcc.size).to eq 1
@@ -24,6 +25,25 @@ module Commontator
       expect(mail.subject).not_to be_empty
       expect(mail.body).not_to be_empty
       expect(mail.deliver_now).to eq mail
+    end
+
+    context 'uses Mailgun' do
+      let(:recipient_variables) do
+        @recipients.each_with_object({}) { |user, memo| memo[user.email] = { label: user.email } }
+      end
+      before { allow(Rails.application.config.action_mailer).to receive(:delivery_method).and_return(:mailgun) }
+
+      it 'must create deliverable mail' do
+        mail = SubscriptionsMailer.comment_created(@comment, @recipients)
+        expect(mail.to.size).to eq 1
+        expect(mail.to).to include(@user2.email)
+        expect(mail.cc).to be_nil
+        expect(mail.bcc.size).to eq 0
+        expect(mail.subject).not_to be_empty
+        expect(mail.body).not_to be_empty
+        expect(mail.deliver_now).to eq mail
+        expect(mail.mailgun_recipient_variables.size).to eq 1
+      end
     end
   end
 end


### PR DESCRIPTION
Hi, thanks for that awesome gem!
Since I'm using [Mailgun](http://mailgun.com) for delivering messages in the production environment, I had to make a few changes in `SubscriptionsMailer`. `mailgun_rails` gem expects the array of recipients in `to` field instead of `bcc`. Additionaly you have to set `mailgun_recipient_variables` to perform [batch sending](https://github.com/jorgemanrubia/mailgun_rails#user-content-recipient-variables-for-batch-sending).

With those changes user doesn't need to overwrite `SubscriptionsMailer` in case he's using a Mailgun.