### PR TITLE
Direct link to comment

### DIFF
--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -23,7 +23,7 @@ module Commontator
 
       @commontable_name = Commontator.commontable_name(@thread)
 
-      @commontable_url = Commontator.commontable_url(@thread, main_app)
+      @commontable_url = Commontator.commontable_url(@comment, main_app)
 
       params = Hash.new
       params[:comment] = @comment

--- a/config/initializers/commontator.rb
+++ b/config/initializers/commontator.rb
@@ -236,14 +236,17 @@ Commontator.configure do |config|
 
   # commontable_url_proc
   # Type: Proc
-  # Arguments: a thread (Commontator::Thread),
+  # Arguments: a comment (Commontator::Comment),
   #            the app_routes (ActionDispatch::Routing::RoutesProxy)
   # Returns: a String containing the url of the view that displays the given thread
   # This usually is the commontable's "show" page
   # The main application's routes can be accessed through the app_routes object
-  # Default: lambda { |commontable, app_routes|
-  #            app_routes.polymorphic_url(commontable) }
+  # Default: lambda { |comment, app_routes|
+  #            app_routes.polymorphic_url(comment.thread.commontable) }
+  # Link to comment:
+  #          lambda { |comment, app_routes|
+  #            app_routes.polymorphic_url(comment.thread.commontable, anchor: "comment_#{comment.id}_div") }
   # (defaults to the commontable's show url)
-  config.commontable_url_proc = lambda { |thread, app_routes|
-    app_routes.polymorphic_url(thread.commontable) }
+  config.commontable_url_proc = lambda { |comment, app_routes|
+    app_routes.polymorphic_url(comment.thread.commontable) }
 end

--- a/lib/commontator.rb
+++ b/lib/commontator.rb
@@ -129,8 +129,8 @@ module Commontator
     commontable_config(commontable).commontable_name_proc.call(commontable)
   end
 
-  def self.commontable_url(commontable, routing_proxy)
-    commontable_config(commontable).commontable_url_proc.call(commontable, routing_proxy)
+  def self.commontable_url(comment, routing_proxy)
+    commontable_config(comment.thread).commontable_url_proc.call(comment, routing_proxy)
   end
 end
 


### PR DESCRIPTION
It might be useful to have an access to `Commontator::Comment instance` in `commontable_url_proc` when we would like to have a direct link to certain comment.