### PR TITLE
Link to comment

### DIFF
--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -8,7 +8,7 @@ module Commontator
                      :subject => t('commontator.email.comment_created.subject',
                                    :creator_name => @creator_name,
                                    :commontable_name => @commontable_name,
-                                   :commontable_url => @commontable_url)
+                                   :comment_url => @comment_url)
 
       message.mailgun_recipient_variables = mailgun_recipient_variables(recipients) if uses_mailgun?
     end
@@ -24,7 +24,7 @@ module Commontator
 
       @commontable_name = Commontator.commontable_name(@thread)
 
-      @commontable_url = Commontator.commontable_url(@comment, main_app)
+      @comment_url = Commontator.comment_url(@comment, main_app)
 
       params = Hash.new
       params[:comment] = @comment
@@ -32,7 +32,7 @@ module Commontator
       params[:creator] = @creator
       params[:creator_name] = @creator_name
       params[:commontable_name] = @commontable_name
-      params[:commontable_url] = @commontable_url
+      params[:comment_url] = @comment_url
 
       if uses_mailgun?
         @to = recipient_emails(recipients)

--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -24,7 +24,7 @@ module Commontator
 
       @commontable_name = Commontator.commontable_name(@thread)
 
-      @commontable_url = Commontator.commontable_url(@thread, main_app)
+      @commontable_url = Commontator.commontable_url(@comment, main_app)
 
       params = Hash.new
       params[:comment] = @comment

--- a/app/views/commontator/subscriptions_mailer/comment_created.html.erb
+++ b/app/views/commontator/subscriptions_mailer/comment_created.html.erb
@@ -6,5 +6,5 @@
            :locals => { :comment => @comment } %>
 
 <p><%= t 'commontator.email.thread_link_html',
-         :commontable_url => @commontable_url,
+         :comment_url => @comment_url,
          :commontable_name => @commontable_name %></p>

--- a/config/initializers/commontator.rb
+++ b/config/initializers/commontator.rb
@@ -236,16 +236,19 @@ Commontator.configure do |config|
 
   # commontable_url_proc
   # Type: Proc
-  # Arguments: a thread (Commontator::Thread),
+  # Arguments: a comment (Commontator::Comment),
   #            the app_routes (ActionDispatch::Routing::RoutesProxy)
   # Returns: a String containing the url of the view that displays the given thread
   # This usually is the commontable's "show" page
   # The main application's routes can be accessed through the app_routes object
-  # Default: lambda { |commontable, app_routes|
-  #                   app_routes.polymorphic_url(commontable) }
+  # Default: lambda { |comment, app_routes|
+  #            app_routes.polymorphic_url(comment.thread.commontable) }
+  # Link to comment:
+  #          lambda { |comment, app_routes|
+  #            app_routes.polymorphic_url(comment.thread.commontable, anchor: "comment_#{comment.id}_div") }
   # (defaults to the commontable's show url)
-  config.commontable_url_proc = lambda { |thread, app_routes|
-    app_routes.polymorphic_url(thread.commontable) }
+  config.commontable_url_proc = lambda { |comment, app_routes|
+    app_routes.polymorphic_url(comment.thread.commontable) }
 
   # mentions_enabled
   # Type: Boolean

--- a/config/initializers/commontator.rb
+++ b/config/initializers/commontator.rb
@@ -234,21 +234,19 @@ Commontator.configure do |config|
   config.commontable_name_proc = lambda { |thread|
     "#{thread.commontable.class.name} ##{thread.commontable.id}" }
 
-  # commontable_url_proc
+  # comment_url_proc
   # Type: Proc
   # Arguments: a comment (Commontator::Comment),
   #            the app_routes (ActionDispatch::Routing::RoutesProxy)
-  # Returns: a String containing the url of the view that displays the given thread
+  # Returns: a String containing the url of the view that displays the given comment
   # This usually is the commontable's "show" page
   # The main application's routes can be accessed through the app_routes object
   # Default: lambda { |comment, app_routes|
-  #            app_routes.polymorphic_url(comment.thread.commontable) }
-  # Link to comment:
-  #          lambda { |comment, app_routes|
-  #            app_routes.polymorphic_url(comment.thread.commontable, anchor: "comment_#{comment.id}_div") }
-  # (defaults to the commontable's show url)
-  config.commontable_url_proc = lambda { |comment, app_routes|
-    app_routes.polymorphic_url(comment.thread.commontable) }
+  #                   app_routes.polymorphic_url(comment.thread.commontable,
+  #                                              anchor: "comment_#{comment.id}_div") }
+  # (defaults to the commontable's show url with an anchor pointing to the comment's div)
+  config.comment_url_proc = lambda { |comment, app_routes|
+    app_routes.polymorphic_url(comment.thread.commontable, anchor: "comment_#{comment.id}_div") }
 
   # mentions_enabled
   # Type: Boolean

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
       comment_created: 
         body: "%{creator_name} commented on %{commontable_name}:"
         subject: "%{creator_name} posted a comment on %{commontable_name}"
-      thread_link_html: "<a href=\"%{commontable_url}\">Click here</a> to view all comments on %{commontable_name}."
+      thread_link_html: "<a href=\"%{comment_url}\">Click here</a> to view all comments on %{commontable_name}."
       undisclosed_recipients: "Undisclosed Recipients"
     require_login: "You must login before you can post a comment."
     subscription: 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -47,7 +47,7 @@ ru:
       comment_created: 
         body: "%{creator_name} комментировал %{commontable_name}:"
         subject: "%{creator_name} оставил комментарий к %{commontable_name}"
-      thread_link_html: "<a href=\"%{commontable_url}\">Нажмите здесь</a> чтобы посмотреть все комментарии к %{commontable_name}."
+      thread_link_html: "<a href=\"%{comment_url}\">Нажмите здесь</a> чтобы посмотреть все комментарии к %{commontable_name}."
       undisclosed_recipients: "Не указан получатель"
     require_login: "Вы должны залогиниться прежде чем оставить комментарий."
     subscription: 

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -47,7 +47,7 @@ zh:
       comment_created: 
         body: "%{creator_name}留言於%{commontable_name}"
         subject: "%{creator_name}於%{commontable_name}發佈了一則留言"
-      thread_link_html: "<a href=\"%{commontable_url}\">點此處</a>看%{commontable_name}的所有留言"
+      thread_link_html: "<a href=\"%{comment_url}\">點此處</a>看%{commontable_name}的所有留言"
       undisclosed_recipients: "收件者"
     require_login: "你需要先登入"
     subscription: 

--- a/lib/commontator.rb
+++ b/lib/commontator.rb
@@ -36,7 +36,7 @@ module Commontator
     :thread_subscription,
     :email_from_proc,
     :commontable_name_proc,
-    :commontable_url_proc
+    :comment_url_proc
   ]
   
   DEPRECATED_ATTRIBUTES = [
@@ -77,7 +77,8 @@ module Commontator
     [:user_email_method, :user_email_proc],
     [:user_name_method, :user_name_proc],
     [:commontable_name, :commontable_name_proc],
-    [:commontable_id_method]
+    [:commontable_id_method],
+    [:commontable_url_proc, :comment_url_proc]
   ]
   
   (ENGINE_ATTRIBUTES + COMMONTATOR_ATTRIBUTES + \
@@ -107,8 +108,8 @@ module Commontator
     (user && user.is_commontator) ? user.commontator_config : self
   end
 
-  def self.commontable_config(user)
-    (user && user.is_commontable) ? user.commontable_config : self
+  def self.commontable_config(obj)
+    (obj && obj.is_commontable) ? obj.commontable_config : self
   end
 
   def self.commontator_name(user)
@@ -135,8 +136,8 @@ module Commontator
     commontable_config(commontable).commontable_name_proc.call(commontable)
   end
 
-  def self.commontable_url(comment, routing_proxy)
-    commontable_config(comment.thread).commontable_url_proc.call(comment, routing_proxy)
+  def self.comment_url(comment, routing_proxy)
+    commontable_config(comment.thread.commontable).comment_url_proc.call(comment, routing_proxy)
   end
 end
 

--- a/lib/commontator.rb
+++ b/lib/commontator.rb
@@ -135,8 +135,8 @@ module Commontator
     commontable_config(commontable).commontable_name_proc.call(commontable)
   end
 
-  def self.commontable_url(commontable, routing_proxy)
-    commontable_config(commontable).commontable_url_proc.call(commontable, routing_proxy)
+  def self.commontable_url(comment, routing_proxy)
+    commontable_config(comment.thread).commontable_url_proc.call(comment, routing_proxy)
   end
 end
 


### PR DESCRIPTION
- Pass comment instead of thread to commontable_url_proc
- Deprecated `commontable_url_proc` in favor of `comment_url_proc`