### PR TITLE
Add thread argument to user_mentions_proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,13 @@ Then enable mentions in commontator's initializer:
 config.mentions_enabled = true
 ```
 
-Finally configure the user_mentions_proc, which receives the current user
-and the search query inputted by that user and should return a relation
-containing the users that can be mentioned and match the query string:
+Finally configure the user_mentions_proc, which receives the current user,
+the current thread, and the search query inputted by that user and should
+return a relation containing the users that can be mentioned and match the
+query string:
 
 ```rb
-config.user_mentions_proc = lambda { |current_user, query| ... }
+config.user_mentions_proc = lambda { |current_user, thread, query| ... }
 ```
 
 Please be aware that with mentions enabled, any registered user

--- a/app/controllers/commontator/comments_controller.rb
+++ b/app/controllers/commontator/comments_controller.rb
@@ -151,7 +151,7 @@ module Commontator
     end
 
     def subscribe_mentioned
-      Commontator.commontator_mentions(@user, '').where(id: params[:mentioned_ids]).each do |user|
+      Commontator.commontator_mentions(@user, @thread, '').where(id: params[:mentioned_ids]).each do |user|
         @thread.subscribe(user)
       end
     end

--- a/app/controllers/commontator/threads_controller.rb
+++ b/app/controllers/commontator/threads_controller.rb
@@ -60,7 +60,7 @@ module Commontator
     protected
 
     def serialized_mentions(query)
-      { mentions: Commontator.commontator_mentions(@user, query).map do |user|
+      { mentions: Commontator.commontator_mentions(@user, @thread, query).map do |user|
         { id: user.id, name: Commontator.commontator_name(user), type: 'user' }
       end }
     end

--- a/config/initializers/commontator.rb
+++ b/config/initializers/commontator.rb
@@ -261,6 +261,7 @@ Commontator.configure do |config|
   # Type: Proc
   # Arguments:
   #   the current user (acts_as_commontator)
+  #   the current thread (Commontator::Thread)
   #   the search query inputted by user (String)
   # Returns: an ActiveRecord Relation object
   # Important notes:
@@ -275,6 +276,6 @@ Commontator.configure do |config|
   #
   # Default: lambda { |current_user, query|
   #                   current_user.class.where('username LIKE ?', "#{query}%") }
-  config.user_mentions_proc = lambda { |current_user, query|
+  config.user_mentions_proc = lambda { |current_user, thread, query|
     current_user.class.where('username LIKE ?', "#{query}%") }
 end

--- a/lib/commontator.rb
+++ b/lib/commontator.rb
@@ -128,8 +128,8 @@ module Commontator
     commontator_config(user).user_avatar_proc.call(user, view)
   end
 
-  def self.commontator_mentions(user, search_phrase)
-    commontator_config(user).user_mentions_proc.call(user, search_phrase)
+  def self.commontator_mentions(user, thread, search_phrase)
+    commontator_config(user).user_mentions_proc.call(user, thread, search_phrase)
   end
 
   def self.commontable_name(commontable)

--- a/spec/controllers/commontator/threads_controller_spec.rb
+++ b/spec/controllers/commontator/threads_controller_spec.rb
@@ -199,7 +199,7 @@ module Commontator
 
             it 'calls the user_mentions_proc and returns the result' do
               expect(Commontator.user_mentions_proc).to(
-                receive(:call).with(@user, search_phrase).and_return(valid_result)
+                receive(:call).with(@user, @thread, search_phrase).and_return(valid_result)
               )
 
               call_request

--- a/spec/dummy/config/initializers/commontator.rb
+++ b/spec/dummy/config/initializers/commontator.rb
@@ -14,7 +14,7 @@ Commontator.configure do |config|
 
   config.mentions_enabled = true
 
-  config.user_mentions_proc = lambda { |current_user, query|
+  config.user_mentions_proc = lambda { |current_user, thread, query|
     'DummyUser'.include?(query) ? DummyUser.all : DummyUser.none }
 end
 


### PR DESCRIPTION
In a project I’m working on I don’t have the concept of user’s friends, or contacts, or anything like that, to decide the possible list of users that can be mentioned. I rather rely on the object commented on to populate such a list of users. So I need the thread argument, to get the commontable object and from there decide the users to display. This pull request tries to achieve that.
