### PR TITLE
replace alias_method_chain with Module#prepend

### DIFF
--- a/lib/commontator/acts_as_commontable.rb
+++ b/lib/commontator/acts_as_commontable.rb
@@ -7,7 +7,7 @@ module Commontator
       base.is_commontable = false
       base.extend(ClassMethods)
     end
-    
+
     module ClassMethods
       def acts_as_commontable(options = {})
         class_eval do
@@ -20,19 +20,21 @@ module Commontator
 
           validates_presence_of :thread
 
-          def thread_with_commontator
-            @thread ||= thread_without_commontator
-            return @thread unless @thread.nil?
-
-            @thread = build_thread
-            @thread.save if persisted?
-            @thread
-          end
-
-          alias_method_chain :thread, :commontator
+          prepend ThreadWithCommontator
         end
       end
-      
+
+      module ThreadWithCommontator
+        def thread
+          @thread ||= super
+          return @thread unless @thread.nil?
+
+          @thread = build_thread
+          @thread.save if persisted?
+          @thread
+        end
+      end
+
       alias_method :acts_as_commentable, :acts_as_commontable
     end
   end


### PR DESCRIPTION
remove deprecation warning on Rails 5:
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in acts_as_commontable at /Users/jd/Documents/rails/commontator/lib/commontator/acts_as_commontable.rb:32)
