### PR TITLE
remove use of alias_method_chain

### DIFF
--- a/app/controllers/commontator/application_controller.rb
+++ b/app/controllers/commontator/application_controller.rb
@@ -1,6 +1,6 @@
 module Commontator
   class ApplicationController < ActionController::Base
-    before_actions :set_user, :ensure_user
+    before_action :set_user, :ensure_user
 
     rescue_from SecurityTransgression, :with => lambda { head(:forbidden) }
 

--- a/app/controllers/commontator/application_controller.rb
+++ b/app/controllers/commontator/application_controller.rb
@@ -1,9 +1,9 @@
 module Commontator
   class ApplicationController < ActionController::Base
-    before_filter :set_user, :ensure_user
-    
+    before_actions :set_user, :ensure_user
+
     rescue_from SecurityTransgression, :with => lambda { head(:forbidden) }
-    
+
     protected
 
     def security_transgression_unless(check)

--- a/app/controllers/commontator/comments_controller.rb
+++ b/app/controllers/commontator/comments_controller.rb
@@ -1,7 +1,7 @@
 module Commontator
   class CommentsController < Commontator::ApplicationController
-    before_filter :set_thread, :only => [:new, :create]
-    before_filter :set_comment_and_thread, :except => [:new, :create]
+    before_action :set_thread, :only => [:new, :create]
+    before_action :set_comment_and_thread, :except => [:new, :create]
 
     # GET /threads/1/comments/new
     def new
@@ -16,7 +16,7 @@ module Commontator
         format.html { redirect_to @thread }
         format.js
       end
-     
+
     end
 
     # POST /threads/1/comments
@@ -27,7 +27,7 @@ module Commontator
       @comment.body = params[:comment].nil? ? nil : params[:comment][:body]
       security_transgression_unless @comment.can_be_created_by?(@user)
       subscribe_mentioned if Commontator.mentions_enabled
-      
+
       respond_to do |format|
         if  !params[:cancel].nil?
           format.html { redirect_to @thread }
@@ -91,7 +91,7 @@ module Commontator
         format.js { render :delete }
       end
     end
-    
+
     # PUT /comments/1/undelete
     def undelete
       security_transgression_unless @comment.can_be_deleted_by?(@user)
@@ -104,11 +104,11 @@ module Commontator
         format.js { render :delete }
       end
     end
-    
+
     # PUT /comments/1/upvote
     def upvote
       security_transgression_unless @comment.can_be_voted_on_by?(@user)
-      
+
       @comment.upvote_from @user
 
       respond_to do |format|
@@ -116,12 +116,12 @@ module Commontator
         format.js { render :vote }
       end
     end
-    
+
     # PUT /comments/1/downvote
     def downvote
       security_transgression_unless @comment.can_be_voted_on_by?(@user) &&\
         @comment.thread.config.comment_voting.to_sym == :ld
-      
+
       @comment.downvote_from @user
 
       respond_to do |format|
@@ -129,11 +129,11 @@ module Commontator
         format.js { render :vote }
       end
     end
-    
+
     # PUT /comments/1/unvote
     def unvote
       security_transgression_unless @comment.can_be_voted_on_by?(@user)
-      
+
       @comment.unvote :voter => @user
 
       respond_to do |format|
@@ -141,9 +141,9 @@ module Commontator
         format.js { render :vote }
       end
     end
-    
+
     protected
-    
+
     def set_comment_and_thread
       @comment = Comment.find(params[:id])
       @thread = @comment.thread

--- a/app/controllers/commontator/subscriptions_controller.rb
+++ b/app/controllers/commontator/subscriptions_controller.rb
@@ -1,6 +1,6 @@
 module Commontator
   class SubscriptionsController < Commontator::ApplicationController
-    before_filter :set_thread
+    before_action :set_thread
 
     # PUT /threads/1/subscribe
     def subscribe

--- a/app/controllers/commontator/threads_controller.rb
+++ b/app/controllers/commontator/threads_controller.rb
@@ -1,7 +1,7 @@
 module Commontator
   class ThreadsController < Commontator::ApplicationController
-    skip_before_filter :ensure_user, :only => :show
-    before_filter :set_thread
+    skip_before_action :ensure_user, :only => :show
+    before_action :set_thread
 
     # GET /threads/1
     def show
@@ -13,7 +13,7 @@ module Commontator
         format.js
       end
     end
-    
+
     # PUT /threads/1/close
     def close
       security_transgression_unless @thread.can_be_edited_by?(@user)
@@ -28,7 +28,7 @@ module Commontator
         format.js { render :show }
       end
     end
-    
+
     # PUT /threads/1/reopen
     def reopen
       security_transgression_unless @thread.can_be_edited_by?(@user)

--- a/lib/commontator/acts_as_commontable.rb
+++ b/lib/commontator/acts_as_commontable.rb
@@ -7,7 +7,7 @@ module Commontator
       base.is_commontable = false
       base.extend(ClassMethods)
     end
-    
+
     module ClassMethods
       def acts_as_commontable(options = {})
         class_eval do
@@ -29,10 +29,11 @@ module Commontator
             @thread
           end
 
-          alias_method_chain :thread, :commontator
+          alias_method :thread_without_commontator, :thread
+          alias_method :thread, :thread_with_commontator
         end
       end
-      
+
       alias_method :acts_as_commentable, :acts_as_commontable
     end
   end

--- a/spec/dummy/app/controllers/dummy_models_controller.rb
+++ b/spec/dummy/app/controllers/dummy_models_controller.rb
@@ -1,5 +1,5 @@
 class DummyModelsController < ApplicationController
-  before_filter :get_dummy
+  before_action :get_dummy
 
   def show
     commontator_thread_show(@dummy_model)


### PR DESCRIPTION
alias_method_chain has been deprecated as of rails 5 and removed as of rails 5.1

addresses: https://github.com/lml/commontator/issues/105