### PR TITLE
Add local time gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 
 # jquery-rails is used by the dummy application
 gem 'jquery-rails'
+gem 'local_time'
 
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or

--- a/app/assets/javascripts/commontator/application.js
+++ b/app/assets/javascripts/commontator/application.js
@@ -1,3 +1,4 @@
 //= require underscore/underscore
 //= require mentionsInput/jquery.mentionsInput
 //= require commontator/mentions
+//= require local-time

--- a/app/helpers/commontator/application_helper.rb
+++ b/app/helpers/commontator/application_helper.rb
@@ -1,7 +1,19 @@
 module Commontator
   module ApplicationHelper
+    include LocalTimeHelper
+
     def javascript_proc
       Commontator.javascript_proc.call(self).html_safe
+    end
+
+    def created_timestamp comment
+      t 'commontator.comment.status.created_at', :created_at => local_time_ago(comment.created_at)
+    end
+
+    def updated_timestamp comment
+      t 'commontator.comment.status.updated_at',
+        :editor_name => Commontator.commontator_name(comment.editor || comment.creator),
+        :updated_at =>  local_time_ago(comment.updated_at)
     end
   end
 end

--- a/app/helpers/commontator/application_helper.rb
+++ b/app/helpers/commontator/application_helper.rb
@@ -7,11 +7,11 @@ module Commontator
     end
 
     def created_timestamp comment
-      t 'commontator.comment.status.created_at', :created_at => local_time_ago(comment.created_at)
+      t 'commontator.comment.status.created_at_html', :created_at => local_time_ago(comment.created_at)
     end
 
     def updated_timestamp comment
-      t 'commontator.comment.status.updated_at',
+      t 'commontator.comment.status.updated_at_html',
         :editor_name => Commontator.commontator_name(comment.editor || comment.creator),
         :updated_at =>  local_time_ago(comment.updated_at)
     end

--- a/app/models/commontator/comment.rb
+++ b/app/models/commontator/comment.rb
@@ -62,17 +62,6 @@ module Commontator
       self.save
     end
 
-    def created_timestamp
-      I18n.t 'commontator.comment.status.created_at',
-             created_at: I18n.l(created_at, format: :commontator)
-    end
-
-    def updated_timestamp
-      I18n.t 'commontator.comment.status.updated_at',
-             editor_name: Commontator.commontator_name(editor || creator),
-             updated_at: I18n.l(updated_at, format: :commontator)
-    end
-
     ##################
     # Access Control #
     ##################

--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -36,12 +36,12 @@
   </div>
   <div id="comment_<%= comment.id.to_s %>_bottom_div" class="comment_div">
     <span id="comment_<%= comment.id.to_s %>_created_timestamp_span" class="comment_timestamp">
-      <%= comment.created_timestamp %>
+      <%= created_timestamp comment %>
     </span>
     <br/>
     <span id="comment_<%= comment.id.to_s %>_updated_timestamp_span" class="comment_timestamp">
     <% if comment.is_modified? %>
-      <%= comment.updated_timestamp %>
+      <%= updated_timestamp comment %>
     <% end %>
     </span>
   </div>

--- a/app/views/commontator/comments/delete.js.erb
+++ b/app/views/commontator/comments/delete.js.erb
@@ -2,7 +2,7 @@ $("#comment_<%= @comment.id.to_s %>_body_div").html("<%= escape_javascript(
   render partial: 'body', locals: { comment: @comment }) %>");
 
 $("#comment_<%= @comment.id.to_s %>_updated_timestamp_span").html("<%= escape_javascript(
-  @comment.updated_timestamp) %>");
+  updated_timestamp @comment) %>");
                                                            
 $("#comment_<%= @comment.id.to_s %>_actions_span").html("<%= escape_javascript(
   render partial: 'actions',

--- a/app/views/commontator/comments/update.js.erb
+++ b/app/views/commontator/comments/update.js.erb
@@ -2,6 +2,6 @@ $("#comment_<%= @comment.id.to_s %>_body_div").html("<%= escape_javascript(
   render partial: 'body', locals: { comment: @comment }) %>");
 
 $("#comment_<%= @comment.id.to_s %>_updated_timestamp_span").html("<%= escape_javascript(
-  @comment.updated_timestamp) %>");
+  updated_timestamp @comment) %>");
 
 <%= javascript_proc %>

--- a/commontator.gemspec
+++ b/commontator.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 5.0"
   s.add_dependency "jquery-rails"
+  s.add_dependency "local_time"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"

--- a/config/initializers/commontator.rb
+++ b/config/initializers/commontator.rb
@@ -22,8 +22,8 @@ Commontator.configure do |config|
   # Objects visible in view templates can be accessed
   # through the view object (for example, view.flash)
   # However, the view does not include the main application's helpers
-  # Default: ->(view) { '$("#error_explanation").remove();' }
-  config.javascript_proc = ->(view) { '$("#error_explanation").remove();' }
+  # Default: ->(view) { '$("#error_explanation").remove(); $(document).trigger("time:elapse");' }
+  config.javascript_proc = ->(view) { '$("#error_explanation").remove(); $(document).trigger("time:elapse");' }
 
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,9 +62,9 @@ en:
         not_deleted: "This comment is not deleted."
         update: "This comment could not be modified because:"
       status:
-        created_at: "Posted on %{created_at}."
+        created_at: "Posted %{created_at}."
         deleted_by: "Comment deleted by %{deleter_name}."
-        updated_at: "Last modified by %{editor_name} on %{updated_at}."
+        updated_at: "Last modified by %{editor_name} %{updated_at}."
     email:
       comment_created:
         body: "%{creator_name} commented on %{commontable_name}:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,9 +62,9 @@ en:
         not_deleted: "This comment is not deleted."
         update: "This comment could not be modified because:"
       status:
-        created_at: "Posted %{created_at}."
+        created_at_html: "Posted %{created_at}."
         deleted_by: "Comment deleted by %{deleter_name}."
-        updated_at: "Last modified by %{editor_name} %{updated_at}."
+        updated_at_html: "Last modified by %{editor_name} %{updated_at}."
     email:
       comment_created:
         body: "%{creator_name} commented on %{commontable_name}:"

--- a/spec/helpers/commontator/application_helper_spec.rb
+++ b/spec/helpers/commontator/application_helper_spec.rb
@@ -18,15 +18,13 @@ module Commontator
       @comment.save!
 
       expect(created_timestamp @comment).to eq(
-        I18n.t('commontator.comment.status.created_at',
-               :created_at => local_time_ago(@comment.created_at,
-                                             :format => :commontator))
+        I18n.t('commontator.comment.status.created_at_html',
+               :created_at => local_time_ago(@comment.created_at))
       )
       expect(updated_timestamp @comment).to eq(
-        I18n.t('commontator.comment.status.updated_at',
+        I18n.t('commontator.comment.status.updated_at_html',
                :editor_name => @user.name,
-               :updated_at => local_time_ago(@comment.updated_at,
-                                             :format => :commontator))
+               :updated_at => local_time_ago(@comment.updated_at))
       )
 
       user2 = DummyUser.create
@@ -35,15 +33,13 @@ module Commontator
       @comment.save!
 
       expect(created_timestamp @comment).to eq(
-        I18n.t('commontator.comment.status.created_at',
-               :created_at => local_time_ago(@comment.created_at,
-                                             :format => :commontator))
+        I18n.t('commontator.comment.status.created_at_html',
+               :created_at => local_time_ago(@comment.created_at))
       )
       expect(updated_timestamp @comment).to eq(
-        I18n.t('commontator.comment.status.updated_at',
+        I18n.t('commontator.comment.status.updated_at_html',
                :editor_name => user2.name,
-               :updated_at => local_time_ago(@comment.updated_at,
-                                             :format => :commontator))
+               :updated_at => local_time_ago(@comment.updated_at))
       )
     end
   end

--- a/spec/helpers/commontator/application_helper_spec.rb
+++ b/spec/helpers/commontator/application_helper_spec.rb
@@ -2,8 +2,49 @@ require 'rails_helper'
 
 module Commontator
   RSpec.describe ApplicationHelper, type: :helper do
+    before(:each) do
+      setup_model_spec
+      @comment = Comment.new
+      @comment.thread = @thread
+      @comment.creator = @user
+      @comment.body = 'Something'
+    end
+
     it 'must print output of javascript proc' do
       expect(javascript_proc).to eq '// Some javascript'
+    end
+
+    it 'must make proper timestamps' do
+      @comment.save!
+
+      expect(created_timestamp @comment).to eq(
+        I18n.t('commontator.comment.status.created_at',
+               :created_at => local_time_ago(@comment.created_at,
+                                             :format => :commontator))
+      )
+      expect(updated_timestamp @comment).to eq(
+        I18n.t('commontator.comment.status.updated_at',
+               :editor_name => @user.name,
+               :updated_at => local_time_ago(@comment.updated_at,
+                                             :format => :commontator))
+      )
+
+      user2 = DummyUser.create
+      @comment.body = 'Something else'
+      @comment.editor = user2
+      @comment.save!
+
+      expect(created_timestamp @comment).to eq(
+        I18n.t('commontator.comment.status.created_at',
+               :created_at => local_time_ago(@comment.created_at,
+                                             :format => :commontator))
+      )
+      expect(updated_timestamp @comment).to eq(
+        I18n.t('commontator.comment.status.updated_at',
+               :editor_name => user2.name,
+               :updated_at => local_time_ago(@comment.updated_at,
+                                             :format => :commontator))
+      )
     end
   end
 end

--- a/spec/models/commontator/comment_spec.rb
+++ b/spec/models/commontator/comment_spec.rb
@@ -44,39 +44,6 @@ module Commontator
 
       expect(@comment.is_deleted?).to eq false
     end
-
-    it 'must make proper timestamps' do
-      @comment.save!
-
-      expect(@comment.created_timestamp).to eq(
-        I18n.t('commontator.comment.status.created_at',
-               created_at: I18n.l(@comment.created_at,
-                                     format: :commontator))
-      )
-      expect(@comment.updated_timestamp).to eq(
-        I18n.t('commontator.comment.status.updated_at',
-               editor_name: @user.name,
-               updated_at: I18n.l(@comment.updated_at,
-                                     format: :commontator))
-      )
-
-      user2 = DummyUser.create
-      @comment.body = 'Something else'
-      @comment.editor = user2
-      @comment.save!
-
-      expect(@comment.created_timestamp).to eq(
-        I18n.t('commontator.comment.status.created_at',
-               created_at: I18n.l(@comment.created_at,
-                                     format: :commontator))
-      )
-      expect(@comment.updated_timestamp).to eq(
-        I18n.t('commontator.comment.status.updated_at',
-               editor_name: user2.name,
-               updated_at: I18n.l(@comment.updated_at,
-                                     format: :commontator))
-      )
-    end
   end
 end
 


### PR DESCRIPTION
> Local Time makes it easy to display times and dates to users in their local time. Its Rails helpers render <time> elements in UTC (making them cache friendly), and its JavaScript component immediately converts those elements from UTC to the browser's local time.

https://github.com/basecamp/local_time