### PR TITLE
fix updated timestamp after create

### DIFF
--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -39,10 +39,8 @@
       <%= comment.created_timestamp %>
     </span>
     <br/>
-    <span id="comment_<%= comment.id.to_s %>_updated_timestamp_span" class="comment_timestamp">
-    <% if comment.is_modified? %>
+    <span id="comment_<%= comment.id.to_s %>_updated_timestamp_span" class="comment_timestamp" style="<%= 'display: none;' unless comment.is_modified? %>">
       <%= comment.updated_timestamp %>
-    <% end %>
     </span>
   </div>
 </div>

--- a/app/views/commontator/comments/delete.js.erb
+++ b/app/views/commontator/comments/delete.js.erb
@@ -2,8 +2,8 @@ $("#comment_<%= @comment.id.to_s %>_body_div").html("<%= escape_javascript(
   render partial: 'body', locals: { comment: @comment }) %>");
 
 $("#comment_<%= @comment.id.to_s %>_updated_timestamp_span").html("<%= escape_javascript(
-  @comment.updated_timestamp) %>");
-                                                           
+  @comment.updated_timestamp) %>").show();
+
 $("#comment_<%= @comment.id.to_s %>_actions_span").html("<%= escape_javascript(
   render partial: 'actions',
          locals: { comment: @comment,

--- a/app/views/commontator/comments/update.js.erb
+++ b/app/views/commontator/comments/update.js.erb
@@ -2,6 +2,6 @@ $("#comment_<%= @comment.id.to_s %>_body_div").html("<%= escape_javascript(
   render partial: 'body', locals: { comment: @comment }) %>");
 
 $("#comment_<%= @comment.id.to_s %>_updated_timestamp_span").html("<%= escape_javascript(
-  @comment.updated_timestamp) %>");
+  @comment.updated_timestamp) %>").show();
 
 <%= javascript_proc %>


### PR DESCRIPTION
When a comment is created the `span#comment_{id}_updated_timestamp_span` is not rendered. If the user edits the comment before reloading the page, the updated date is not shown. This PR fixes this.