### PR TITLE
wrap ActionController::Base to prevent deprecation messages (issue 160)

### DIFF
--- a/lib/commontator/controllers.rb
+++ b/lib/commontator/controllers.rb
@@ -31,4 +31,6 @@ module Commontator::Controllers
   end
 end
 
-ActionController::Base.send :include, Commontator::Controllers
+ActiveSupport.on_load(:action_controller) do
+  ActionController::Base.send :include, Commontator::Controllers
+end

--- a/lib/commontator/shared_helper.rb
+++ b/lib/commontator/shared_helper.rb
@@ -57,5 +57,7 @@ module Commontator::SharedHelper
   end
 end
 
-ActionController::Base.send :include, Commontator::SharedHelper
-ActionController::Base.helper Commontator::SharedHelper
+ActiveSupport.on_load(:action_controller) do
+  ActionController::Base.send :include, Commontator::SharedHelper
+  ActionController::Base.helper Commontator::SharedHelper
+end


### PR DESCRIPTION
On a Fresh Rails 6 App with the Gems rspec-rails and commontator installed, when running rspec the following deprecation warnings come up:

```
alaarab@PanamaJack:~/Sites/myapp$ rspec

The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <top (required)> at /mnt/c/Users/Panama Jack/Documents/GitHub/myapp/config/environment.rb:5)
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <main> at /mnt/c/Users/Panama Jack/Documents/GitHub/myapp/config/environment.rb:5)
```