### PR TITLE
Changes hidden to commontator-hidden to prevent conflicts with bootstrap (issue 156)

### DIFF
--- a/app/assets/stylesheets/commontator/application.scss
+++ b/app/assets/stylesheets/commontator/application.scss
@@ -11,7 +11,7 @@
     padding: 0;
   }
 
-  .hidden {
+  .commontator-hidden {
     display: none;
   }
 

--- a/app/views/commontator/threads/_reply.html.erb
+++ b/app/views/commontator/threads/_reply.html.erb
@@ -19,7 +19,7 @@
     <% end %>
 
     <div id="commontator-thread-<%= thread.id %>-new-comment" class="new-comment<%=
-    @commontator_new_comment.nil? ? ' hidden' : '' %>">
+    @commontator_new_comment.nil? ? ' commontator-hidden' : '' %>">
       <% unless @commontator_new_comment.nil? %>
         <%=
           render partial: 'commontator/comments/form', locals: {

--- a/app/views/commontator/threads/_show.html.erb
+++ b/app/views/commontator/threads/_show.html.erb
@@ -11,7 +11,7 @@
   nested_comments = thread.nested_comments_for(user, comments, show_all)
 %>
 
-<div id="commontator-thread-<%= thread.id %>-show" class="show hidden">
+<div id="commontator-thread-<%= thread.id %>-show" class="show commontator-hidden">
   <%= link_to t('commontator.thread.actions.show'),
               '#',
               id: "commontator-thread-#{thread.id}-show-link" %>
@@ -20,7 +20,7 @@
 <div id="commontator-thread-<%= thread.id %>-content" class="content">
   <div id="commontator-thread-<%= thread.id %>-header" class="header">
     <span id="commontator-thread-<%= thread.id %>-actions" class="actions">
-      <span id="commontator-thread-<%= thread.id %>-hide" class="hide hidden">
+      <span id="commontator-thread-<%= thread.id %>-hide" class="hide commontator-hidden">
         <%= link_to t('commontator.thread.actions.hide'),
                     '#',
                     id: "commontator-thread-#{thread.id}-hide-link" %>


### PR DESCRIPTION
This resolves conflicts with other CSS packages such as bootstrap by changing the hidden class to commontator-hidden.