### PR TITLE
fixes Ruby 2.7 deprecation warnings

### DIFF
--- a/lib/commontator/acts_as_commontable.rb
+++ b/lib/commontator/acts_as_commontable.rb
@@ -17,7 +17,7 @@ module Commontator::ActsAsCommontable
         cattr_accessor :commontable_config
         self.commontable_config = Commontator::CommontableConfig.new(options)
 
-        has_one :commontator_thread, association_options.merge(
+        has_one :commontator_thread, **association_options.merge(
           as: :commontable, class_name: 'Commontator::Thread'
         )
 

--- a/lib/commontator/acts_as_commontator.rb
+++ b/lib/commontator/acts_as_commontator.rb
@@ -16,10 +16,10 @@ module Commontator::ActsAsCommontator
         cattr_accessor :commontator_config
         self.commontator_config = Commontator::CommontatorConfig.new(options)
 
-        has_many :commontator_comments, association_options.merge(
+        has_many :commontator_comments, **association_options.merge(
           as: :creator, class_name: 'Commontator::Comment'
         )
-        has_many :commontator_subscriptions, association_options.merge(
+        has_many :commontator_subscriptions, **association_options.merge(
           as: :subscriber, class_name: 'Commontator::Subscription'
         )
 


### PR DESCRIPTION
This fixes the deprecation warnings caused by Ruby 2.7 due to the deprecation of conversion of keyword arguments.