### PR TITLE
Use symbols for polymorphic route arguments

### DIFF
--- a/app/views/commontator/comments/_show.html.erb
+++ b/app/views/commontator/comments/_show.html.erb
@@ -36,7 +36,7 @@
       <% is_deleted = comment.is_deleted? %>
       <% del_string = is_deleted ? 'undelete' : 'delete' %>
       <%= link_to t("commontator.comment.actions.#{del_string}"),
-                  commontator.polymorphic_path([del_string, comment]),
+                  commontator.polymorphic_path([del_string.to_sym, comment]),
                   data: is_deleted ? {} : { confirm: t('commontator.comment.actions.confirm_delete') },
                   method: :put,
                   id: "commontator-comment-#{comment.id}-#{del_string}",

--- a/app/views/commontator/subscriptions/_link.html.erb
+++ b/app/views/commontator/subscriptions/_link.html.erb
@@ -7,7 +7,7 @@
 <% is_subscribed = !!thread.subscription_for(user) %>
 <% sub_string = is_subscribed ? 'unsubscribe' : 'subscribe' %>
 <%= link_to t("commontator.subscription.actions.#{sub_string}"),
-            commontator.polymorphic_path([sub_string, thread]),
+            commontator.polymorphic_path([sub_string.to_sym, thread]),
             method: :put,
             id: "commontator-thread-#{thread.id}-#{sub_string}",
             class: sub_string,

--- a/app/views/commontator/threads/_show.html.erb
+++ b/app/views/commontator/threads/_show.html.erb
@@ -54,7 +54,7 @@
         <% end %>
 
         <%= link_to t("commontator.thread.actions.#{close_string}"),
-                    commontator.polymorphic_path([close_string, thread]),
+                    commontator.polymorphic_path([close_string.to_sym, thread]),
                     data: is_closed ? {} :
                                       { confirm: t('commontator.thread.actions.confirm_close') },
                     method: :put,


### PR DESCRIPTION
Same as #186 by purpose, but without wrong and reverting commits

Rails 6 introduces a "please use symbols for polymorphic route arguments" error, when strings are used in polymorphic_path and arguments inside redirect_to and link_to. This PR fixes that error in Commontator

More info about error: https://github.com/rails/rails/issues/42157