### PR TITLE
Fix render for Rails 7

### DIFF
--- a/app/views/commontator/threads/_show.html.erb
+++ b/app/views/commontator/threads/_show.html.erb
@@ -110,5 +110,5 @@
 </div>
 
 <script type="text/javascript">
-  <%= render partial: 'commontator/threads/hide_show_links.js', locals: { thread: thread } %>
+  <%= render partial: 'commontator/threads/hide_show_links', locals: { thread: thread } %>
 </script>


### PR DESCRIPTION
Template names with dot were forbidden in https://github.com/rails/rails/commit/85ecf6e4098601222b604f7c1cbdcb4e49a6d1f0#diff-82dd8abd58264f9fe9de27f3be5016cca3e4722346825f39419e6c596e54ad9f