### PR TITLE
Update and rename file to built as a partial

### DIFF
--- a/app/views/commontator/threads/_hide_show_links.html.erb
+++ b/app/views/commontator/threads/_hide_show_links.html.erb
@@ -2,7 +2,7 @@
   Views that use this partial must supply the following variables:
   thread
 %>
-
+<script>
 $("#commontator-thread-<%= thread.id %>-hide-link").click(function() {
   $("#commontator-thread-<%= thread.id %>-content").hide();
 
@@ -22,3 +22,4 @@ $("#commontator-thread-<%= thread.id %>-show-link").click(function() {
 });
 
 $("#commontator-thread-<%= thread.id %>-hide").show();
+</script>


### PR DESCRIPTION
Don't recognize .js.erb file when is request shown the comments threads.
I change the filename and include <script> tag to act as .js file

```
ActionView::Template::Error (Missing partial commontator/threads/_hide_show_links with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby]}.

Searched in:
  * "/home/nicof/Documents/projects/rails/rateMyIdea/app/views"
  * "/home/nicof/.asdf/installs/ruby/3.0.2/lib64/ruby/gems/3.0.0/gems/avo-1.17.1/app/views"
  * "/home/nicof/.asdf/installs/ruby/3.0.2/lib64/ruby/gems/3.0.0/gems/view_component-2.47.0/app/views"
  * "/home/nicof/.asdf/installs/ruby/3.0.2/lib64/ruby/gems/3.0.0/gems/devise-4.8.1/app/views"
  * "/home/nicof/.asdf/installs/ruby/3.0.2/lib64/ruby/gems/3.0.0/gems/commontator-7.0.0/app/views"
  * "/home/nicof/.asdf/installs/ruby/3.0.2/lib64/ruby/gems/3.0.0/gems/actionmailbox-7.0.0/app/views"
):
    110: </div>
    111: 
    112: <script type="text/javascript">
    113:   <%= render partial: 'commontator/threads/hide_show_links', locals: { thread: thread } %>
    114: </script>

```


Not the most polite to do so, but it's simply and just works.